### PR TITLE
Use correct variable when interpolating region to pack AMI within

### DIFF
--- a/packer/vault.json.example
+++ b/packer/vault.json.example
@@ -14,7 +14,7 @@
     {
       "name": "vault",
       "type": "amazon-ebs",
-      "region": "{{ user `vault_version` }}",
+      "region": "{{ user `builder_region` }}",
       "source_ami_filter": {
         "filters": {
           "name": "CentOS Linux 7 x86_64 HVM EBS *"


### PR DESCRIPTION
Previously, this yielded an error:

```
* Unknown region: 0.8.3
```