### PR TITLE
add required version

### DIFF
--- a/terraform/main/version.tf
+++ b/terraform/main/version.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "< 0.12"
+}

--- a/terraform/modules/vault/version.tf
+++ b/terraform/modules/vault/version.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "< 0.12"
+}


### PR DESCRIPTION
This PR just adds the terraform `required_version` field, which should prevent anyone from attempting to use this with terraform `0.12` (breaking changes) and above.

A future PR will update this code to work with `0.12`

@knehring I think after we merge this we should add a `1.0.0` tag to master and then a PR to support `0.12` that will use the `2.0.0` tag.