### PR TITLE
Updates primarily around Ansible

### DIFF
--- a/packer/ansible/roles/vault/defaults/main.yml
+++ b/packer/ansible/roles/vault/defaults/main.yml
@@ -1,0 +1,3 @@
+vault_binary_dir: "/usr/local/bin"
+vault_cert_dir: "/usr/local/etc/vault/tls"
+vault_config_dir: "/usr/local/etc/vault"

--- a/packer/ansible/roles/vault/tasks/main.yml
+++ b/packer/ansible/roles/vault/tasks/main.yml
@@ -44,7 +44,7 @@
         serole: object_r
         setype: usr_t
         selevel: s0
-        checksum: "{{ vault_version_checksum }}"
+        checksum: "sha256:{{ vault_version_checksum }}"
 
     - name: Unarchive Vault
       unarchive:

--- a/packer/ansible/roles/vault/tasks/main.yml
+++ b/packer/ansible/roles/vault/tasks/main.yml
@@ -69,7 +69,7 @@
 
     - name: cleanup vault zip
       file:
-        path: "/usr/local/src/packer_{{ vault_version }}_linux_amd64.zip"
+        path: "/usr/local/src/vault_{{ vault_version }}_linux_amd64.zip"
         state: absent
 
 # Create Vault files and directories

--- a/packer/ansible/roles/vault/tasks/main.yml
+++ b/packer/ansible/roles/vault/tasks/main.yml
@@ -122,14 +122,6 @@
         setype: bin_t
         selevel: s0
 
-    - name: selinux - vault config directory
-      file:
-        path: /etc/vault
-        seuser: system_u
-        serole: object_r
-        setype: etc_t
-        selevel: s0
-
     - name: selinux - vault certificates directory
       file:
         path: "{{ vault_cert_dir }}"
@@ -138,12 +130,12 @@
         setype: cert_t
         selevel: s0
 
-    - name: selinux - vault systemd unit file
+    - name: selinux - vault config directory
       file:
-        path: /etc/systemd/system/vault.service
+        path: "{{ vault_config_dir }}" 
         seuser: system_u
         serole: object_r
-        setype: systemd_unit_file_t
+        setype: etc_t
         selevel: s0
 
     - name: selinux - vault profile.d
@@ -152,6 +144,14 @@
         seuser: system_u
         serole: object_r
         setype: bin_t
+        selevel: s0
+
+    - name: selinux - vault systemd unit file
+      file:
+        path: /etc/systemd/system/vault.service
+        seuser: system_u
+        serole: object_r
+        setype: systemd_unit_file_t
         selevel: s0
 
   when: ansible_os_family == "RedHat"

--- a/packer/ansible/roles/vault/tasks/main.yml
+++ b/packer/ansible/roles/vault/tasks/main.yml
@@ -69,7 +69,7 @@
 
     - name: cleanup vault zip
       file:
-        path: "/usr/local/src/packer_{{ packer_version }}_linux_amd64.zip"
+        path: "/usr/local/src/packer_{{ vault_version }}_linux_amd64.zip"
         state: absent
 
 # Create Vault files and directories

--- a/packer/ansible/roles/vault/tasks/main.yml
+++ b/packer/ansible/roles/vault/tasks/main.yml
@@ -14,6 +14,17 @@
     - wget
     - unzip
 
+- name: Install EPEL
+  package:
+    name: "epel-release"
+    state: present
+  when: ansible_distribution in ["CentOS", "RedHat"]
+
+- name: install aws cli
+  package:
+    name: awscli
+    state: present
+
 - name: Create the Vault Group
   group:
     name: vault
@@ -27,95 +38,120 @@
     system: yes
     group: vault
     createhome: no
-    home: /srv/vault/
+    home: "{{ vault_config_dir }}"
     shell: /sbin/nologin
     comment: A service account to run Vault
 
-- name: Install Vault
-  block:
-    - name: Download Vault
+# Install Vault
+- block:
+    - name: download vault zip
       get_url:
-        url: https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version }}_linux_amd64.zip
-        dest: /usr/src/vault_{{ vault_version }}_linux_amd64.zip
+        url: "https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version }}_linux_amd64.zip"
+        dest: "/usr/local/src/vault_{{ vault_version }}_linux_amd64.zip"
         owner: root
         group: root
         mode: 0744
-        seuser: system_u
-        serole: object_r
-        setype: usr_t
-        selevel: s0
         checksum: "sha256:{{ vault_version_checksum }}"
 
-    - name: Unarchive Vault
+    - name: unarchive vault zip
       unarchive:
-        src: /usr/src/vault_{{ vault_version }}_linux_amd64.zip
-        dest: /usr/bin
+        src: "/usr/local/src/vault_{{ vault_version }}_linux_amd64.zip"
+        dest: "{{ vault_binary_dir }}"
         remote_src: True
 
-    - name: Set Vault Permissions
+    - name: set permissions on vault binary
       file:
-        path: /usr/bin/vault
+        path: "{{ vault_binary_dir }}/vault"
         state: file
         owner: root
-        group: vault
+        group: root
         mode: 0755
+
+    - name: cleanup vault zip
+      file:
+        path: "/usr/local/src/packer_{{ packer_version }}_linux_amd64.zip"
+        state: absent
+
+# Create Vault files and directories
+- block:
+    - name: create vault config directory
+      file:
+        path: "{{ vault_config_dir }}"
+        state: directory
+        owner: root
+        group: vault
+        mode: 0750
+
+    - name: create vault certificates directory
+      file:
+        path: "{{ vault_cert_dir }}"
+        state: directory
+        owner: root
+        group: vault
+        mode: 0750
+
+- name: Add the Vault Service
+  template:
+    src: vault.service.j2
+    dest: /etc/systemd/system/vault.service
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Add Vault Global Env Vars
+  template:
+    src: profile.d_vault.sh.j2
+    dest: /etc/profile.d/vault.sh
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Allow Vault to Lock Memory
+  capabilities:
+    state: present
+    path: "{{ vault_binary_dir }}/vault"
+    capability: cap_ipc_lock=+ep
+
+# ensure SELinux contexts if RedHat family
+- block:
+    - name: selinux - vault binary
+      file:
+        path: "{{ vault_binary_dir }}/vault"
         seuser: system_u
         serole: object_r
         setype: bin_t
         selevel: s0
 
-- name: Create the Vault Files and Folders
-  block:
-    - name: Main Folder
+    - name: selinux - vault config directory
       file:
         path: /etc/vault
-        state: directory
-        owner: root
-        group: vault
-        mode: 0755
         seuser: system_u
         serole: object_r
         setype: etc_t
         selevel: s0
 
-    - name: SSL Folder
+    - name: selinux - vault certificates directory
       file:
-        path: /etc/vault/ssl
-        state: directory
-        owner: root
-        group: vault
-        mode: 0755
+        path: "{{ vault_cert_dir }}"
         seuser: system_u
         serole: object_r
         setype: cert_t
         selevel: s0
 
-- name: Add the Vault Service
-  copy:
-    src: vault.service
-    dest: /etc/systemd/system/vault.service
-    owner: root
-    group: vault
-    mode: 0755
-    seuser: system_u
-    serole: object_r
-    setype: systemd_unit_file_t
-    selevel: s0
+    - name: selinux - vault systemd unit file
+      file:
+        path: /etc/systemd/system/vault.service
+        seuser: system_u
+        serole: object_r
+        setype: systemd_unit_file_t
+        selevel: s0
 
-- name: Add Vault Global Env Vars
-  copy:
-    src: profile.d_vault.sh
-    dest: /etc/profile.d/vault.sh
-    owner: root
-    group: vault
-    mode: 0644
-    seuser: system_u
-    serole: object_r
-    setype: bin_t
-    selevel: s0
+    - name: selinux - vault profile.d
+      file:
+        path: /etc/profile.d/vault.sh
+        seuser: system_u
+        serole: object_r
+        setype: bin_t
+        selevel: s0
 
-- name: Allow Vault to Lock Memory
-  capabilities:
-    state: present
-    path: /usr/bin/vault
-    capability: cap_ipc_lock=+ep
+  when: ansible_os_family == "RedHat"

--- a/packer/ansible/roles/vault/templates/profile.d_vault.sh.j2
+++ b/packer/ansible/roles/vault/templates/profile.d_vault.sh.j2
@@ -1,4 +1,5 @@
 # The MIT License (MIT)
 # Copyright (c) 2014-2019 Avant, Sean Lingren
 
+alias vault='{{ vault_binary }}'
 export VAULT_ADDR='http://127.0.0.1:9200'

--- a/packer/ansible/roles/vault/templates/profile.d_vault.sh.j2
+++ b/packer/ansible/roles/vault/templates/profile.d_vault.sh.j2
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
 # Copyright (c) 2014-2019 Avant, Sean Lingren
 
-alias vault='{{ vault_binary }}'
+alias vault='{{ vault_binary_dir }}/vault'
 export VAULT_ADDR='http://127.0.0.1:9200'

--- a/packer/ansible/roles/vault/templates/vault.service.j2
+++ b/packer/ansible/roles/vault/templates/vault.service.j2
@@ -17,7 +17,7 @@ SecureBits=keep-caps
 Capabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
-ExecStart=/usr/bin/vault server -config=/etc/vault/
+ExecStart={{ vault_binary }} server -config={{ vault_config_dir }}
 KillSignal=SIGINT
 TimeoutStopSec=30s
 Restart=on-failure

--- a/packer/ansible/roles/vault/templates/vault.service.j2
+++ b/packer/ansible/roles/vault/templates/vault.service.j2
@@ -17,7 +17,7 @@ SecureBits=keep-caps
 Capabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
-ExecStart={{ vault_binary }} server -config={{ vault_config_dir }}
+ExecStart={{ vault_binary_dir }}/vault server -config={{ vault_config_dir }}
 KillSignal=SIGINT
 TimeoutStopSec=30s
 Restart=on-failure

--- a/packer/vault.json.example
+++ b/packer/vault.json.example
@@ -3,7 +3,7 @@
     "license": "The MIT License (MIT)",
     "copyright": "Copyright (c) 2014-2019 Avant, Sean Lingren",
     "vault_version": "1.2.3",
-    "vault_version_checksum": "sha256:fe15676404aff35cb45f7c957f90491921b9269d79a8f933c5a36e26a431bfc4",
+    "vault_version_checksum": "fe15676404aff35cb45f7c957f90491921b9269d79a8f933c5a36e26a431bfc4",
     "builder_region": "us-west-1",
     "builder_vpc_id": "vpc-xxxxxxxx",
     "builder_subnet_id": "subnet-xxxxxxxx",

--- a/terraform/modules/vault/data.tf
+++ b/terraform/modules/vault/data.tf
@@ -14,6 +14,8 @@ data "template_file" "userdata" {
   vars = {
     name_prefix                 = var.name_prefix
     region                      = var.region
+    vault_cert_dir              = var.vault_cert_dir
+    vault_config_dir            = var.vault_config_dir
     vault_resources_bucket_name = aws_s3_bucket.vault_resources.id
     vault_data_bucket_name      = aws_s3_bucket.vault_data.id
   }
@@ -25,6 +27,7 @@ data "template_file" "vault_config" {
   vars = {
     name_prefix            = var.name_prefix
     region                 = var.region
+    vault_cert_dir         = var.vault_cert_dir
     vault_dns_address      = var.vault_dns_address
     vault_data_bucket_name = aws_s3_bucket.vault_data.id
     dynamodb_table_name    = var.dynamodb_table_name

--- a/terraform/modules/vault/files/config.hcl
+++ b/terraform/modules/vault/files/config.hcl
@@ -25,8 +25,8 @@ listener "tcp" {
 
   tls_disable     = "false"
   tls_min_version = "tls12"
-  tls_cert_file   = "/etc/vault/ssl/cert.crt"
-  tls_key_file    = "/etc/vault/ssl/privkey.key"
+  tls_cert_file   = "${ vault_cert_dir }/cert.crt"
+  tls_key_file    = "${ vault_cert_dir }/privkey.key"
 
   tls_prefer_server_cipher_suites = "true"
 }

--- a/terraform/modules/vault/files/userdata.sh
+++ b/terraform/modules/vault/files/userdata.sh
@@ -11,19 +11,19 @@ hostnamectl set-hostname "${ name_prefix }-$INSTANCE_ID"
 systemctl restart rsyslog.service
 
 # Get Configuration and SSL Certs
-aws --region ${ region } s3 cp s3://${ vault_resources_bucket_name }/resources/config/config.hcl /etc/vault/config.hcl
+aws --region ${ region } s3 cp s3://${ vault_resources_bucket_name }/resources/config/config.hcl ${ vault_config_dir }/config.hcl
 
 # https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_key_file
-aws --region ${ region } s3 cp s3://${ vault_resources_bucket_name }/resources/ssl/cert.crt      /etc/vault/ssl/cert.crt
+aws --region ${ region } s3 cp s3://${ vault_resources_bucket_name }/resources/ssl/cert.crt      ${ vault_cert_dir }/cert.crt
 
 # https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_client_ca_file
-aws --region ${ region } s3 cp s3://${ vault_resources_bucket_name }/resources/ssl/privkey.key   /etc/vault/ssl/privkey.key
+aws --region ${ region } s3 cp s3://${ vault_resources_bucket_name }/resources/ssl/privkey.key   ${ vault_cert_dir }/privkey.key
 
 # Get My IP Address
 MYIP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
 
 # Add My IP Address as cluster_address in Vault Configuration
-sed -i -e "s/MY_IP_SET_IN_USERDATA/$MYIP/g" /etc/vault/config.hcl
+sed -i -e "s/MY_IP_SET_IN_USERDATA/$MYIP/g" ${ vault_config_dir }/config.hcl
 
 # Start Vault now and on boot
 systemctl enable vault

--- a/terraform/modules/vault/variables.tf
+++ b/terraform/modules/vault/variables.tf
@@ -95,6 +95,22 @@ variable "asg_desired_capacity" {
 }
 
 ############################
+## OS ######################
+############################
+
+variable "vault_cert_dir" {
+  type        = string
+  description = "The directory on the OS to store Vault certificates"
+  default     = "/usr/local/etc/vault/tls"
+}
+
+variable "vault_config_dir" {
+  type        = string
+  description = "The directory on the OS to store the Vault configuration"
+  default     = "/usr/local/etc/vault"
+}
+
+############################
 ## S3 ######################
 ############################
 variable "vault_resources_bucket_name" {


### PR DESCRIPTION
Hello!

Although it is not compatible with https://github.com/avantoss/vault-infra/pull/15, I wanted to open this PR to propose some enhancements centered around the Ansible role and work towards multi-os support that I will do my best to summarize:

- use variables for vault binary, config and certificate directories, and default them to `/usr/local` to follow the convention of using these directories for software not installed via a package (such as RPM or DPKG). Also make these variables with default values in the terraform.

- Work towards multi-os by adding a conditional for EPEL if `ansible_distribution` is CentOS or RedHat. Also add a stand alone task to install `awscli` - I have tested on Amazon Linux 2, CentOS, Debian and Ubuntu, and the package name is that exact spelling on all of them, so this should work without any conditionals.

- Add `sha256:` to the task that pulls the vault archive so that we don't have to include it in the variable value (hashicorp does not publish checksums other than sha256sums for their software so it is reasonable to hard set this).

- Add task to delete Vault zip once the binary is unarchived

- A few adjustments to filesystem permissions: `0750` for vault configuration and certificate directories so that users other than root and those in the vault group cannot access the files inside. `644` permissions for the systemd unit file as these are the correct permissions.

- Move SELinux context setting outside of main tasks and into a block that gets conditionally triggered if `ansible_os_family == "RedHat"`. This means that the role should work for distributions such as Debian and Ubuntu that do not use SELinux.