### PR TITLE
Dependabot, Versions, Actions, Deprecations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lingrino

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      time: "09:00"
+      interval: daily
+    allow:
+      - dependency-type: all
+    assignees:
+      - lingrino
+    reviewers:
+      - lingrino
+    labels:
+      - dependencies
+      - actions
+
+  - package-ecosystem: terraform
+    directory: /terraform/main
+    schedule:
+      time: "09:00"
+      interval: daily
+    allow:
+      - dependency-type: all
+    assignees:
+      - lingrino
+    reviewers:
+      - lingrino
+    labels:
+      - dependencies
+      - go
+
+  - package-ecosystem: terraform
+    directory: /terraform/modules/vault
+    schedule:
+      time: "09:00"
+      interval: daily
+    allow:
+      - dependency-type: all
+    assignees:
+      - lingrino
+    reviewers:
+      - lingrino
+    labels:
+      - dependencies
+      - go

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -1,6 +1,7 @@
 name: Packer
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - packer/**
@@ -10,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code - Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: Packer - Install
@@ -23,7 +24,7 @@ jobs:
         env:
           PACKER_VERSION: "1.6.0"
       - name: Ansible Lint
-        uses: ansible/ansible-lint-action@master
+        uses: ansible/ansible-lint-action@v2
         with:
           targets: packer/ansible/**/*.yml
       - name: Packer - Validate

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           PACKER_VERSION: "1.6.0"
       - name: Ansible Lint
-        uses: ansible/ansible-lint-action@v2
+        uses: ansible/ansible-lint-action@master
         with:
           targets: packer/ansible/**/*.yml
       - name: Packer - Validate

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: License Exists

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,6 +1,7 @@
 name: Terraform
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - terraform/**
@@ -10,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code - Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: Terraform - Install
@@ -21,6 +22,6 @@ jobs:
           sudo chmod 755 /usr/local/bin/terraform
           rm -f /tmp/terraform.zip
         env:
-          TERRAFORM_VERSION: "0.12.28"
+          TERRAFORM_VERSION: "0.12.29"
       - name: Terraform Format
         run: terraform fmt -check -diff -recursive

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There are a number of features unique to this module that make it attractive for
 
 ## Vault Architecture
 
-![Architecture Map](https://raw.githubusercontent.com/grem11n/vault-infra/master/_docs/architecture.png)
+![Architecture Map](https://raw.githubusercontent.com/avantoss/vault-infra/HEAD/_docs/architecture.png)
 
 ## Getting Started
 

--- a/packer/vault.json
+++ b/packer/vault.json
@@ -2,8 +2,8 @@
     "variables": {
         "license": "The MIT License (MIT)",
         "copyright": "Copyright (c) 2014-2020 Avant, Sean Lingren",
-        "vault_version": "1.4.3",
-        "vault_version_checksum": "f486da4f6d08e42eb2c17e95cf36cc7f9d9c0e7cc8ced06ce3fca7c3abd7db3d",
+        "vault_version": "1.5.0",
+        "vault_version_checksum": "322393aee141c4711fc5f9e1df9f461af3a861e59b8d4d0a85e82477cdbc73a0",
         "builder_region": "us-west-1",
         "builder_vpc_id": "vpc-xxxxxxxx",
         "builder_subnet_id": "subnet-xxxxxxxx",

--- a/terraform/modules/vault/ec2.tf
+++ b/terraform/modules/vault/ec2.tf
@@ -26,7 +26,7 @@ resource "aws_launch_template" "lt" {
   network_interfaces {
     device_index                = 0
     associate_public_ip_address = false
-    delete_on_termination       = true
+    delete_on_termination       = "true"
 
     security_groups = [aws_security_group.ec2.id]
   }

--- a/terraform/modules/vault/s3.tf
+++ b/terraform/modules/vault/s3.tf
@@ -3,7 +3,6 @@
 
 resource "aws_s3_bucket" "vault_resources" {
   bucket        = var.vault_resources_bucket_name
-  region        = var.region
   force_destroy = true
 
   acl    = "log-delivery-write"
@@ -72,7 +71,6 @@ resource "aws_s3_bucket" "vault_resources_dr" {
   provider = aws.dr
 
   bucket        = "${var.vault_resources_bucket_name}-dr"
-  region        = var.dr_region
   force_destroy = true
 
   acl = "private"
@@ -101,7 +99,6 @@ resource "aws_s3_bucket" "vault_resources_dr" {
 
 resource "aws_s3_bucket" "vault_data" {
   bucket        = var.vault_data_bucket_name
-  region        = var.region
   force_destroy = true
 
   acl = "private"
@@ -146,7 +143,6 @@ resource "aws_s3_bucket" "vault_data_dr" {
   provider = aws.dr
 
   bucket        = "${var.vault_data_bucket_name}-dr"
-  region        = var.dr_region
   force_destroy = true
 
   acl = "private"


### PR DESCRIPTION
- Add dependabot to keep actions and terraform up to date
- Add myself as codeowners
- Add `workflow_dispatch` to actions to allow manual triggers
- Switch to using versions actions (dependabot will update)
- Update versions of terraform/vault
- Update readme image to use this repo's image
- Remove region from s3 bucket ([deprecated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_s3_bucket))
- Change `delete_on_termination` to a string ([updated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_launch_template))