### PR TITLE
Do not glacier vault logs and allow configuring log expiration and update versions

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -22,7 +22,7 @@ jobs:
           sudo chmod 755 /usr/local/bin/packer
           rm -f /tmp/packer.zip
         env:
-          PACKER_VERSION: "1.6.0"
+          PACKER_VERSION: "1.7.2"
       - name: Ansible Lint
         uses: ansible/ansible-lint-action@master
         with:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -22,6 +22,6 @@ jobs:
           sudo chmod 755 /usr/local/bin/terraform
           rm -f /tmp/terraform.zip
         env:
-          TERRAFORM_VERSION: "0.12.29"
+          TERRAFORM_VERSION: "0.15.5"
       - name: Terraform Format
         run: terraform fmt -check -diff -recursive

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2020, Avant, Sean Lingren
+Copyright (c) 2014-2021, Avant, Sean Lingren
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ For ease of use this module requires that you manually enter the AMI ID of the P
 
 This project is licensed under the MIT License:
 
-Copyright (c) 2014-2020, Avant, Sean Lingren
+Copyright (c) 2014-2021, Avant, Sean Lingren
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/packer/ansible/roles/vault/tasks/main.yml
+++ b/packer/ansible/roles/vault/tasks/main.yml
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 - name: Update all packages
   package:

--- a/packer/ansible/roles/vault/templates/profile.d_vault.sh.j2
+++ b/packer/ansible/roles/vault/templates/profile.d_vault.sh.j2
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 alias vault='{{ vault_binary_dir }}/vault'
 export VAULT_ADDR='http://127.0.0.1:9200'

--- a/packer/ansible/roles/vault/templates/vault.service.j2
+++ b/packer/ansible/roles/vault/templates/vault.service.j2
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 [Unit]
 Description=Vault Server

--- a/packer/ansible/site.yml
+++ b/packer/ansible/site.yml
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 - name: Configure Vault
   hosts: all

--- a/packer/vault.json
+++ b/packer/vault.json
@@ -1,7 +1,7 @@
 {
     "variables": {
         "license": "The MIT License (MIT)",
-        "copyright": "Copyright (c) 2014-2020 Avant, Sean Lingren",
+        "copyright": "Copyright (c) 2014-2021 Avant, Sean Lingren",
         "vault_version": "1.5.0",
         "vault_version_checksum": "322393aee141c4711fc5f9e1df9f461af3a861e59b8d4d0a85e82477cdbc73a0",
         "builder_region": "us-west-1",

--- a/packer/vault.json
+++ b/packer/vault.json
@@ -2,8 +2,8 @@
     "variables": {
         "license": "The MIT License (MIT)",
         "copyright": "Copyright (c) 2014-2021 Avant, Sean Lingren",
-        "vault_version": "1.5.0",
-        "vault_version_checksum": "322393aee141c4711fc5f9e1df9f461af3a861e59b8d4d0a85e82477cdbc73a0",
+        "vault_version": "1.7.2",
+        "vault_version_checksum": "5ee6bb8119b55c27cd3864c982177714a0a4a3813927ccafdb262e78e4bb67bc",
         "builder_region": "us-west-1",
         "builder_vpc_id": "vpc-xxxxxxxx",
         "builder_subnet_id": "subnet-xxxxxxxx",

--- a/terraform/main/providers.tf
+++ b/terraform/main/providers.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 provider "aws" {
   region = var.region

--- a/terraform/main/terraform.tfvars.example
+++ b/terraform/main/terraform.tfvars.example
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 ############################
 ## Environment #############

--- a/terraform/main/variables.tf
+++ b/terraform/main/variables.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 ############################
 ## Environment #############

--- a/terraform/main/vault.tf
+++ b/terraform/main/vault.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 module "vault" {
   source = "../modules/vault"

--- a/terraform/main/version.tf
+++ b/terraform/main/version.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 terraform {
   required_version = ">= 0.12"

--- a/terraform/modules/vault/acm.tf
+++ b/terraform/modules/vault/acm.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 resource "aws_acm_certificate" "acm" {
   count             = var.alb_certificate_arn == "" ? 1 : 0

--- a/terraform/modules/vault/alb.tf
+++ b/terraform/modules/vault/alb.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 resource "aws_lb" "alb" {
   name            = replace(var.name_prefix, "_", "-")

--- a/terraform/modules/vault/config.tf
+++ b/terraform/modules/vault/config.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 # Upload config to S3
 resource "aws_s3_bucket_object" "object" {

--- a/terraform/modules/vault/data.tf
+++ b/terraform/modules/vault/data.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 # Returns the account ID that is calling the terraform
 data "aws_caller_identity" "current" {}

--- a/terraform/modules/vault/ec2.tf
+++ b/terraform/modules/vault/ec2.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 resource "aws_launch_template" "lt" {
   name_prefix = "${var.name_prefix}-"

--- a/terraform/modules/vault/files/config.hcl
+++ b/terraform/modules/vault/files/config.hcl
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 cluster_name      = "${ name_prefix }"
 max_lease_ttl     = "192h" # One week

--- a/terraform/modules/vault/files/userdata.sh
+++ b/terraform/modules/vault/files/userdata.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 # Get the Instance ID
 INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)

--- a/terraform/modules/vault/iam.tf
+++ b/terraform/modules/vault/iam.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 ############################
 ## S3 ######################

--- a/terraform/modules/vault/kms.tf
+++ b/terraform/modules/vault/kms.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 resource "aws_kms_alias" "seal" {
   name          = "alias/${var.name_prefix}/seal"

--- a/terraform/modules/vault/locals.tf
+++ b/terraform/modules/vault/locals.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 locals {
   plain_domain = replace(element(split(":", var.vault_dns_address), 1), "////", "")

--- a/terraform/modules/vault/policies.tf
+++ b/terraform/modules/vault/policies.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 ############################
 ## S3 ######################

--- a/terraform/modules/vault/providers.tf
+++ b/terraform/modules/vault/providers.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 provider "aws" {
   alias  = "dr"

--- a/terraform/modules/vault/route53.tf
+++ b/terraform/modules/vault/route53.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 resource "aws_route53_record" "www" {
   count   = var.route53_enabled ? 1 : 0

--- a/terraform/modules/vault/s3.tf
+++ b/terraform/modules/vault/s3.tf
@@ -24,13 +24,8 @@ resource "aws_s3_bucket" "vault_resources" {
 
     abort_incomplete_multipart_upload_days = 7
 
-    transition {
-      days          = "30"
-      storage_class = "GLACIER"
-    }
-
     expiration {
-      days = "300"
+      days = var.vault_logs_retention_days
     }
   }
 

--- a/terraform/modules/vault/s3.tf
+++ b/terraform/modules/vault/s3.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 resource "aws_s3_bucket" "vault_resources" {
   bucket        = var.vault_resources_bucket_name

--- a/terraform/modules/vault/sgs.tf
+++ b/terraform/modules/vault/sgs.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 ############################
 ## ALB #####################

--- a/terraform/modules/vault/variables.tf
+++ b/terraform/modules/vault/variables.tf
@@ -135,6 +135,12 @@ variable "vault_data_bucket_name" {
   description = "The name of the vault data bucket"
 }
 
+variable "vault_logs_retention_days" {
+  type        = string
+  description = "The number of days to retain vault logs in S3"
+  default     = 300
+}
+
 ############################
 ## DynamoDB ################
 ############################

--- a/terraform/modules/vault/variables.tf
+++ b/terraform/modules/vault/variables.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 ############################
 ## Environment #############

--- a/terraform/modules/vault/version.tf
+++ b/terraform/modules/vault/version.tf
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014-2020 Avant, Sean Lingren
+# Copyright (c) 2014-2021 Avant, Sean Lingren
 
 terraform {
   required_version = ">= 0.12"


### PR DESCRIPTION
- Logs should not be added to glacier because the file sizes are so small that the added glacier metadata adds costs beyond what gacier itself saves
- We should let users configure how long they retain logs for
- Update the vault, packer, and terraform versions
- Update the license year

closes https://github.com/avantoss/vault-infra/issues/31