### PR TITLE
update for aws provider v4

### DIFF
--- a/terraform/modules/vault/acm.tf
+++ b/terraform/modules/vault/acm.tf
@@ -17,16 +17,23 @@ resource "aws_acm_certificate" "acm" {
 }
 
 resource "aws_route53_record" "dns_acm_validation" {
-  count   = var.alb_certificate_arn == "" ? 1 : 0
-  name    = aws_acm_certificate.acm[0].domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.acm[0].domain_validation_options[0].resource_record_type
+  for_each = var.alb_certificate_arn == "" ? {
+    for dvo in aws_acm_certificate.acm[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  name    = each.value.name
+  type    = each.value.type
   zone_id = var.zone_id
-  records = [aws_acm_certificate.acm[0].domain_validation_options[0].resource_record_value]
+  records = [each.value.record]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "acm_validation" {
   count                   = var.alb_certificate_arn == "" ? 1 : 0
   certificate_arn         = aws_acm_certificate.acm[0].arn
-  validation_record_fqdns = [aws_route53_record.dns_acm_validation[0].fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.dns_acm_validation : record.fqdn]
 }

--- a/terraform/modules/vault/config.tf
+++ b/terraform/modules/vault/config.tf
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2022 Avant, Sean Lingren
 
 # Upload config to S3
-resource "aws_s3_bucket_object" "object" {
+resource "aws_s3_object" "object" {
   bucket  = aws_s3_bucket.vault_resources.id
   key     = "resources/config/config.hcl"
   content = data.template_file.vault_config.rendered

--- a/terraform/modules/vault/ec2.tf
+++ b/terraform/modules/vault/ec2.tf
@@ -90,8 +90,12 @@ resource "aws_autoscaling_group" "asg" {
     "GroupTotalInstances",
   ]
 
-  tags = [
-    for k, v in var.tags :
-    { "key" : k, "value" : v, "propagate_at_launch" : "true" }
-  ]
+  dynamic "tag" {
+    for_each = var.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = "true"
+    }
+  }
 }

--- a/terraform/modules/vault/s3.tf
+++ b/terraform/modules/vault/s3.tf
@@ -5,61 +5,89 @@ resource "aws_s3_bucket" "vault_resources" {
   bucket        = var.vault_resources_bucket_name
   force_destroy = true
 
-  acl    = "log-delivery-write"
-  policy = data.aws_iam_policy_document.s3_vault_resources_bucket_policy.json
-
-  versioning {
-    enabled = true
-  }
-
-  logging {
-    target_bucket = var.vault_resources_bucket_name
-    target_prefix = "logs/s3_access_logs/"
-  }
-
-  lifecycle_rule {
-    id      = "vault-logs-s3-lifecycle-rule"
-    enabled = true
-    prefix  = "logs/"
-
-    abort_incomplete_multipart_upload_days = 7
-
-    expiration {
-      days = var.vault_logs_retention_days
-    }
-  }
-
-  lifecycle_rule {
-    id      = "vault-resources-s3-lifecycle-rule"
-    enabled = true
-    prefix  = "resources/"
-
-    abort_incomplete_multipart_upload_days = 7
-
-    noncurrent_version_expiration {
-      days = "7"
-    }
-  }
-
-  replication_configuration {
-    role = aws_iam_role.s3_vault_resources_replicaton_role.arn
-
-    rules {
-      id     = "replicate-vault-resources"
-      status = "Enabled"
-      prefix = "resources/"
-
-      destination {
-        bucket        = aws_s3_bucket.vault_resources_dr.arn
-        storage_class = "STANDARD"
-      }
-    }
-  }
-
   tags = merge(
     { "Name" = var.vault_resources_bucket_name },
     var.tags,
   )
+}
+
+resource "aws_s3_bucket_policy" "vault_resources" {
+  bucket = aws_s3_bucket.vault_resources.id
+  policy = data.aws_iam_policy_document.s3_vault_resources_bucket_policy.json
+}
+
+resource "aws_s3_bucket_acl" "vault_resources" {
+  bucket = aws_s3_bucket.vault_resources.id
+  acl    = "log-delivery-write"
+}
+
+resource "aws_s3_bucket_versioning" "vault_resources" {
+  bucket = aws_s3_bucket.vault_resources.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_logging" "vault_resources" {
+  bucket = aws_s3_bucket.vault_resources.id
+
+  target_bucket = var.vault_resources_bucket_name
+  target_prefix = "logs/s3_access_logs/"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vault_resources_logs" {
+  bucket = aws_s3_bucket.vault_resources.bucket
+
+  rule {
+    id     = "vault-logs-s3-lifecycle-rule"
+    status = "Enabled"
+    prefix = "logs/"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+    expiration {
+      days = var.vault_logs_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vault_resources_resources" {
+  bucket = aws_s3_bucket.vault_resources.bucket
+
+  rule {
+    id     = "vault-resources-s3-lifecycle-rule"
+    status = "Enabled"
+    prefix = "resources/"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket_replication_configuration" "vault_resources" {
+  bucket = aws_s3_bucket.vault_resources.bucket
+
+  role = aws_iam_role.s3_vault_resources_replicaton_role.arn
+
+  rule {
+    id     = "replicate-vault-resources"
+    status = "Enabled"
+    prefix = "resources/"
+
+    destination {
+      bucket        = aws_s3_bucket.vault_resources_dr.arn
+      storage_class = "STANDARD"
+    }
+  }
+
+  # must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.vault_resources]
 }
 
 resource "aws_s3_bucket" "vault_resources_dr" {
@@ -68,70 +96,89 @@ resource "aws_s3_bucket" "vault_resources_dr" {
   bucket        = "${var.vault_resources_bucket_name}-dr"
   force_destroy = true
 
-  acl = "private"
-
-  versioning {
-    enabled = true
-  }
-
-  lifecycle_rule {
-    id      = "vault-resources-s3-lifecycle-rule"
-    enabled = true
-    prefix  = "resources/"
-
-    abort_incomplete_multipart_upload_days = 7
-
-    noncurrent_version_expiration {
-      days = "7"
-    }
-  }
-
   tags = merge(
     { "Name" = var.vault_resources_bucket_name },
     var.tags,
   )
 }
 
+resource "aws_s3_bucket_versioning" "vault_resources_dr" {
+  bucket = aws_s3_bucket.vault_resources_dr.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vault_resources_dr" {
+  bucket = aws_s3_bucket.vault_resources_dr.bucket
+
+  rule {
+    id     = "vault-resources-s3-lifecycle-rule"
+    status = "Enabled"
+    prefix = "resources/"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+}
+
 resource "aws_s3_bucket" "vault_data" {
   bucket        = var.vault_data_bucket_name
   force_destroy = true
-
-  acl = "private"
-
-  versioning {
-    enabled = true
-  }
-
-  lifecycle_rule {
-    id      = "vault-data-s3-lifecycle-rule"
-    enabled = true
-
-    abort_incomplete_multipart_upload_days = 7
-
-    noncurrent_version_expiration {
-      days = "7"
-    }
-  }
-
-  replication_configuration {
-    role = aws_iam_role.s3_vault_data_replicaton_role.arn
-
-    rules {
-      id     = "replicate-vault-data"
-      status = "Enabled"
-      prefix = ""
-
-      destination {
-        bucket        = aws_s3_bucket.vault_data_dr.arn
-        storage_class = "STANDARD"
-      }
-    }
-  }
 
   tags = merge(
     { "Name" = var.vault_data_bucket_name },
     var.tags,
   )
+}
+
+resource "aws_s3_bucket_versioning" "vault_data" {
+  bucket = aws_s3_bucket.vault_data.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vault_data" {
+  bucket = aws_s3_bucket.vault_data.bucket
+
+  rule {
+    id     = "vault-data-s3-lifecycle-rule"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket_replication_configuration" "vault_data" {
+  bucket = aws_s3_bucket.vault_data.bucket
+
+  role = aws_iam_role.s3_vault_data_replicaton_role.arn
+
+  rule {
+    id     = "replicate-vault-data"
+    status = "Enabled"
+    prefix = ""
+
+    destination {
+      bucket        = aws_s3_bucket.vault_data_dr.arn
+      storage_class = "STANDARD"
+    }
+  }
+
+  # must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.vault_data]
 }
 
 resource "aws_s3_bucket" "vault_data_dr" {
@@ -140,25 +187,32 @@ resource "aws_s3_bucket" "vault_data_dr" {
   bucket        = "${var.vault_data_bucket_name}-dr"
   force_destroy = true
 
-  acl = "private"
-
-  versioning {
-    enabled = true
-  }
-
-  lifecycle_rule {
-    id      = "vault-data-s3-lifecycle-rule"
-    enabled = true
-
-    abort_incomplete_multipart_upload_days = 7
-
-    noncurrent_version_expiration {
-      days = "7"
-    }
-  }
-
   tags = merge(
     { "Name" = var.vault_data_bucket_name },
     var.tags,
   )
+}
+
+resource "aws_s3_bucket_versioning" "vault_data_dr" {
+  bucket = aws_s3_bucket.vault_data_dr.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vault_data_dr" {
+  bucket = aws_s3_bucket.vault_data_dr.bucket
+
+  rule {
+    id     = "vault-data-s3-lifecycle-rule"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
 }


### PR DESCRIPTION
- s3 bucket options are all new resources now. people migrating will need to import these new resources
- domain validation options now returns a set
- asg `tags` is deprecated in favor of multiple `tag`
- `aws_s3_bucket_object` is now `aws_s3_object`